### PR TITLE
Upmerge 20.12.24 bt rpc fix

### DIFF
--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -12,7 +12,7 @@
 menuconfig BT_DRIVERS
 	bool "Bluetooth drivers"
 	default y
-	depends on BT
+	depends on BT && BT_HCI
 
 if BT_DRIVERS
 


### PR DESCRIPTION
The BT_DRIVERS symbol default value 'y' used to depend on !BT_CTLR but now it is always on when BT is set. For BT_RPC the BT_DRIVERS symbol must not be enabled on the client side as no driver is used.

The temporary solution is to set BT_DRIVERS to 'y' by default only when BT_HCI stack selection is enabled. It will be 'n' when BT_RPC_STACK is enabled. The fix should be fine as NCS uses either HCI or RPC stack.