### PR TITLE
[nrf noup] tests: secure_storage: fix test w/ ZMS backend on 54L15

### DIFF
--- a/tests/subsys/secure_storage/psa/its/testcase.yaml
+++ b/tests/subsys/secure_storage/psa/its/testcase.yaml
@@ -26,6 +26,7 @@ tests:
     extra_args:
       - EXTRA_DTC_OVERLAY_FILE=zms.overlay
       - EXTRA_CONF_FILE=overlay-secure_storage.conf;overlay-transform_default.conf
+      - SB_CONFIG_PARTITION_MANAGER=n
 
   secure_storage.psa.its.secure_storage.store.settings:
     filter: CONFIG_SECURE_STORAGE_ITS_STORE_IMPLEMENTATION_SETTINGS


### PR DESCRIPTION
noup because it's about partition manager.

Fix the build of secure_storage.psa.its.secure_storage.store.zms on nrf54l15dk/nrf54l15/cpuapp by disabling partition manager, which is incompatible with the ZMS implementation of the ITS store module.

Disabling it only for that test as it's not needed for the others and even makes the NS board targets fail if disabling PM.

supersedes https://github.com/anangl/sdk-zephyr/pull/8