### PR TITLE
[nrf noup] modules: mbedtls: check Kconfig options, not macros

### DIFF
--- a/modules/mbedtls/configs/config-tf-psa-crypto.h
+++ b/modules/mbedtls/configs/config-tf-psa-crypto.h
@@ -296,8 +296,8 @@
 #define MBEDTLS_BIGNUM_C
 #endif
 
-#if defined(MBEDTLS_RSA_C) || \
-    defined(MBEDTLS_X509_USE_C)
+#if defined(CONFIG_MBEDTLS_RSA_C) || \
+    defined(CONFIG_MBEDTLS_X509_USE_C)
 #define MBEDTLS_OID_C
 #endif
 


### PR DESCRIPTION
nrf-squash! [nrf noup] modules: mbedtls: revert removal of deprecated options

Macros are not yet defined because config-mbedtls.h, which includes config-tf-psa-crypto.h, is the one defining them but only after the include.