### PR TITLE
[nrf fromlist] dts: nrf5340: cpunet: add hfxo and lfxo nodes to soc

### DIFF
--- a/dts/arm/nordic/nrf5340_clocks.dtsi
+++ b/dts/arm/nordic/nrf5340_clocks.dtsi
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	clocks {
+		lfxo: lfxo {
+			compatible = "nordic,nrf53-lfxo";
+			#clock-cells = <0>;
+			clock-frequency = <32768>;
+		};
+
+		hfxo: hfxo {
+			compatible = "nordic,nrf53-hfxo";
+			#clock-cells = <0>;
+			clock-frequency = <DT_FREQ_M(32)>;
+			startup-time-us = <1400>;
+		};
+	};
+};

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
 #include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuapp_ns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_ns.dtsi
@@ -9,6 +9,7 @@
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
 #include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	cpus {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -15,19 +15,6 @@ dcnf: dcnf@0 {
 oscillators: clock-controller@4000 {
 	compatible = "nordic,nrf53-oscillators";
 	reg = <0x4000 0x1000>;
-
-	lfxo: lfxo {
-		compatible = "nordic,nrf53-lfxo";
-		#clock-cells = <0>;
-		clock-frequency = <32768>;
-	};
-
-	hfxo: hfxo {
-		compatible = "nordic,nrf53-hfxo";
-		#clock-cells = <0>;
-		clock-frequency = <DT_FREQ_M(32)>;
-		startup-time-us = <1400>;
-	};
 };
 
 regulators: regulator@4000 {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv8-m.dtsi>
 #include <nordic/nrf_common.dtsi>
+#include <arm/nordic/nrf5340_clocks.dtsi>
 
 / {
 	chosen {


### PR DESCRIPTION
The hfxo and lfxo clocks are used by both cpuapp and cpunet cores, but the hfxo and lfxo nodes are only present in devicetree for the cpuapp core. This prevents the cpunet build from knowing if there is an hfxo and/or lfxo present. Therefore add the lfxo and hfxo clocks to nrf5340_cpunet.dtsi

All boards in tree have both the hfxo and lfxo present. The only information that needs to be made available to cpunet is the hfxo's presence and startup time, and lfxo's presence.

Upstream PR #: 105558